### PR TITLE
Add a link to the line number

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckResult/summary.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckResult/summary.jelly
@@ -49,7 +49,15 @@
 
 
               </td>
-              <g:format value="${cppcheckfile.lineNumber}" severity="${cppcheckfile.severity}"/>
+              <td class="pane">
+                <j:if
+                    test="${elt.isSourceIgnored()}">
+                  ${cppcheckfile.lineNumber}
+                </j:if>
+                <j:if test="${not elt.isSourceIgnored()}">
+                  <a href="source.${cppcheckfile.key}#${cppcheckfile.lineNumber}">${cppcheckfile.lineNumber}</a>
+                </j:if>
+              </td>
               <g:format value="${cppcheckfile.cppCheckId}" severity="${cppcheckfile.severity}"/>
               <g:format value="${cppcheckfile.severity}" severity="${cppcheckfile.severity}"/>
               <g:format value="${cppcheckfile.message}" severity="${cppcheckfile.severity}"/>


### PR DESCRIPTION
This patch adds a link to the line number where a cppcheck error accored. It replaces the line number with a link to the source url with #lineNum appended which takes you to the source file with the line where the error occured, at the top of the page.
