### PR TITLE
Add option to not fail builds if a report is not found.

### DIFF
--- a/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/config/CppcheckConfig.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/config/CppcheckConfig.java
@@ -35,6 +35,8 @@ public class CppcheckConfig implements Serializable {
 
     private boolean ignoreBlankFiles;
 
+    private boolean allowNoReport;
+
     private CppcheckConfigSeverityEvaluation configSeverityEvaluation = new CppcheckConfigSeverityEvaluation();
 
     private CppcheckConfigGraph configGraph = new CppcheckConfigGraph();
@@ -44,7 +46,7 @@ public class CppcheckConfig implements Serializable {
 
     @DataBoundConstructor
     @SuppressWarnings("unused")
-    public CppcheckConfig(String cppcheckReportPattern,
+    public CppcheckConfig(String cppcheckReportPattern, boolean allowNoReport,
                           boolean ignoreBlankFiles, String threshold,
                           String newThreshold, String failureThreshold,
                           String newFailureThreshold, String healthy, String unHealthy,
@@ -55,6 +57,7 @@ public class CppcheckConfig implements Serializable {
 
         this.cppcheckReportPattern = cppcheckReportPattern;
         this.ignoreBlankFiles = ignoreBlankFiles;
+        this.allowNoReport = allowNoReport;
         this.configSeverityEvaluation = new CppcheckConfigSeverityEvaluation(
                 threshold, newThreshold, failureThreshold, newFailureThreshold, healthy,
                 unHealthy, severityError, severityPossibleError, severityStyle, severityPossibleStyle);
@@ -71,6 +74,10 @@ public class CppcheckConfig implements Serializable {
 
     public boolean isIgnoreBlankFiles() {
         return ignoreBlankFiles;
+    }
+
+    public boolean isAllowNoReport() {
+        return allowNoReport;
     }
 
     public CppcheckConfigSeverityEvaluation getConfigSeverityEvaluation() {

--- a/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckPublisher.java
@@ -35,6 +35,7 @@ public class CppcheckPublisher extends Recorder {
     @SuppressWarnings("unused")
     public CppcheckPublisher(String pattern,
                              boolean ignoreBlankFiles, String threshold,
+                             boolean allowNoReport,
                              String newThreshold, String failureThreshold,
                              String newFailureThreshold, String healthy, String unHealthy,
                              boolean severityError,
@@ -53,6 +54,7 @@ public class CppcheckPublisher extends Recorder {
         cppcheckConfig = new CppcheckConfig();
 
         cppcheckConfig.setPattern(pattern);
+        cppcheckConfig.setAllowNoReport(allowNoReport);
         cppcheckConfig.setIgnoreBlankFiles(ignoreBlankFiles);
         CppcheckConfigSeverityEvaluation configSeverityEvaluation = new CppcheckConfigSeverityEvaluation(
                 threshold, newThreshold, failureThreshold, newFailureThreshold, healthy, unHealthy,
@@ -113,8 +115,13 @@ public class CppcheckPublisher extends Recorder {
             }
 
             if (cppcheckReport == null) {
-                build.setResult(Result.FAILURE);
-                return false;
+                // Check if we're configured to allow not having a report
+                if (cppcheckConfig.getAllowNoReport()) {
+                    return true;
+                } else {
+                    build.setResult(Result.FAILURE);
+                    return false;
+                }
             }
 
             CppcheckSourceContainer cppcheckSourceContainer = new CppcheckSourceContainer(listener, build.getWorkspace(), build.getModuleRoot(), cppcheckReport.getAllErrors());

--- a/src/main/java/org/jenkinsci/plugins/cppcheck/config/CppcheckConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/config/CppcheckConfig.java
@@ -10,6 +10,7 @@ public class CppcheckConfig implements Serializable {
 
     private String pattern;
     private boolean ignoreBlankFiles;
+    private boolean allowNoReport;
     private CppcheckConfigSeverityEvaluation configSeverityEvaluation = new CppcheckConfigSeverityEvaluation();
     private CppcheckConfigGraph configGraph = new CppcheckConfigGraph();
 
@@ -19,6 +20,10 @@ public class CppcheckConfig implements Serializable {
 
     public void setIgnoreBlankFiles(boolean ignoreBlankFiles) {
         this.ignoreBlankFiles = ignoreBlankFiles;
+    }
+
+    public void setAllowNoReport(boolean allowNoReport) {
+        this.allowNoReport = allowNoReport;
     }
 
     public void setConfigSeverityEvaluation(CppcheckConfigSeverityEvaluation configSeverityEvaluation) {
@@ -52,6 +57,10 @@ public class CppcheckConfig implements Serializable {
 
     public boolean isIgnoreBlankFiles() {
         return ignoreBlankFiles;
+    }
+
+    public boolean getAllowNoReport() {
+        return allowNoReport;
     }
 
     public CppcheckConfigSeverityEvaluation getConfigSeverityEvaluation() {

--- a/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckPublisher/config.jelly
@@ -15,6 +15,11 @@
         <label>${%Ignore blank files}</label>
     </f:entry>
 
+    <f:entry>
+        <f:checkbox name="cppcheck.allowNoReport" checked="${config.allowNoReport}"/>
+        <label>${%Do not fail the build if the Cppcheck report is not found}</label>
+    </f:entry>
+
     <f:advanced>
         <u:thresholds id="cppcheck"/>
     </f:advanced>


### PR DESCRIPTION
Useful in cases where one axis of a matrix build does not generate a CPP
check report.
