### PR TITLE
[JENKINS-18029] Selected line with static analysis violation is hidden because breadcrumb covers it

### DIFF
--- a/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/CppcheckSource.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/CppcheckSource.java
@@ -229,7 +229,6 @@ public class CppcheckSource implements Serializable {
      *
      * @return the source code content as a String object
      */
-    @SuppressWarnings("unused")
     public String getSourceCode() {
         return sourceCode;
     }
@@ -239,7 +238,6 @@ public class CppcheckSource implements Serializable {
      *
      * @return the workspace file
      */
-    @SuppressWarnings("unused")
     public CppcheckWorkspaceFile getCppcheckWorkspaceFile() {
         return cppcheckWorkspaceFile;
     }

--- a/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/model/CppcheckFile.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/model/CppcheckFile.java
@@ -60,6 +60,15 @@ public class CppcheckFile implements ModelObject, Serializable {
         return lineNumber;
     }
 
+    /**
+     * Returns the line number that should be shown on top of the source code view.
+     *
+     * @return the line number
+     */
+    public int getLinkLineNumber() {
+        return Math.max(1, lineNumber - 10);
+    }
+
     public void setLineNumber(int lineNumber) {
         this.lineNumber = lineNumber;
     }
@@ -92,7 +101,6 @@ public class CppcheckFile implements ModelObject, Serializable {
     }
 
     @Exported
-    @SuppressWarnings("unused")
     public Integer getKey() {
         return key;
     }

--- a/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckResult/details.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckResult/details.jelly
@@ -39,7 +39,7 @@
                                 ${cppcheckfile.lineNumber}
                             </j:if>
                             <j:if test="${not elt.isSourceIgnored()}">
-                                <a href="source.${cppcheckfile.key}#${cppcheckfile.lineNumber}">${cppcheckfile.lineNumber}</a>
+                                <a href="source.${cppcheckfile.key}#${cppcheckfile.linkLineNumber}">${cppcheckfile.lineNumber}</a>
                             </j:if>
                         </td>
                         <td class="pane">${cppcheckfile.severity}</td>


### PR DESCRIPTION
- The page with source code now scrolls 10 lines above the highlighted one to be able to see the context.
- @SuppressWarnings("unused") removed to solve compiler warnings.
