### PR TITLE
[JENKINS-14481] Quickly identify only the new errors

### DIFF
--- a/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/model/CppcheckFile.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/model/CppcheckFile.java
@@ -51,6 +51,15 @@ public class CppcheckFile implements ModelObject, Serializable {
         return fileName;
     }
 
+    /**
+     * Get the filename.
+     * 
+     * @return the filename or empty string if the filename is null
+     */
+    public String getFileNameNotNull() {
+        return (fileName != null) ? fileName : "";
+    }
+
     public void setFileName(String filename) {
         this.fileName = filename;
     }
@@ -58,6 +67,15 @@ public class CppcheckFile implements ModelObject, Serializable {
     @Exported
     public int getLineNumber() {
         return lineNumber;
+    }
+
+    /**
+     * Get line number depending on availability of the file name.
+     * 
+     * @return the line number or empty string if the file name is empty
+     */
+    public String getLineNumberString() {
+        return ("".equals(getFileNameNotNull())) ? "" : String.valueOf(lineNumber);
     }
 
     /**
@@ -112,5 +130,4 @@ public class CppcheckFile implements ModelObject, Serializable {
     public String getDisplayName() {
         return "cppcheckFile";
     }
-
 }

--- a/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/model/CppcheckSourceContainer.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/model/CppcheckSourceContainer.java
@@ -67,7 +67,7 @@ public class CppcheckSourceContainer {
             cppcheckFile.setKey(key);
             cppcheckWorkspaceFile.setCppcheckFile(cppcheckFile);
             internalMap.put(key, cppcheckWorkspaceFile);
-            key = ++key;
+            ++key;
         }
     }
 

--- a/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/model/CppcheckWorkspaceFile.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/model/CppcheckWorkspaceFile.java
@@ -25,11 +25,11 @@ package com.thalesgroup.hudson.plugins.cppcheck.model;
 
 import hudson.model.AbstractBuild;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.cppcheck.CppcheckDiffState;
 
 import java.io.File;
 
 public class CppcheckWorkspaceFile {
-
     /**
      * Temporary directory holding the workspace files.
      */
@@ -40,9 +40,17 @@ public class CppcheckWorkspaceFile {
     private CppcheckFile cppcheckFile;
 
     /**
-     * Useful for files that are not found on the buid filestystem
+     * Useful for files that are not found on the build file system
      */
     private boolean sourceIgnored;
+
+    /**
+     * State of compare. It is a runtime parameter, don't store it anywhere
+     * (transient).
+     * 
+     * @since 1.15
+     */
+    private transient CppcheckDiffState diffState = null;
 
     public CppcheckWorkspaceFile(File file) {
         if (file != null)
@@ -103,5 +111,13 @@ public class CppcheckWorkspaceFile {
 
     public void setSourceIgnored(boolean sourceIgnored) {
         this.sourceIgnored = sourceIgnored;
+    }
+
+    public CppcheckDiffState getDiffState() {
+        return diffState;
+    }
+
+    public void setDiffState(CppcheckDiffState diffState) {
+        this.diffState = diffState;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckDiffState.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckDiffState.java
@@ -1,0 +1,65 @@
+package org.jenkinsci.plugins.cppcheck;
+
+/**
+ * Status of comparison of two reports.
+ * 
+ * Implementation note: The declaration order of the constants is significant,
+ * it's used in sorting.
+ * 
+ * @see CppcheckResult#diffCurrentAndPrevious()
+ * @author Michal Turek
+ */
+public enum CppcheckDiffState {
+    /** The issue is present only in the current report. */
+    NEW {
+        @Override
+        public String getCss() {
+            return "new";
+        }
+
+        @Override
+        public String getText() {
+            return Messages.cppcheck_DiffNew();
+        }
+    },
+
+    /** The issue is present only in the previous report. */
+    SOLVED {
+        @Override
+        public String getCss() {
+            return "solved";
+        }
+
+        @Override
+        public String getText() {
+            return Messages.cppcheck_DiffSolved();
+        }
+    },
+
+    /** The issue is present in both the current and the previous report. */
+    UNCHANGED {
+        @Override
+        public String getCss() {
+            return "unchanged";
+        }
+
+        @Override
+        public String getText() {
+            return Messages.cppcheck_DiffUnchanged();
+        }
+    };
+
+    /**
+     * Get CSS class.
+     * 
+     * @return the class
+     */
+    public abstract String getCss();
+
+    /**
+     * Get localized text.
+     * 
+     * @return the localized text
+     */
+    public abstract String getText();
+}

--- a/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckResult/details.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckResult/details.jelly
@@ -1,7 +1,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:g="/jelly/cppcheck">
     <st:header name="Content-Type" value="text/html;charset=UTF-8"/>
 
-    <j:set var="cachedContainer" value="${it.cppcheckSourceContainer}"/>
+    <j:set var="cachedContainer" value="${it.diffCurrentAndPrevious()}"/>
 
     <j:if test="${cachedContainer != null}">
 
@@ -10,11 +10,15 @@
         <style type="text/css">
         #cppcheckDetails { width: auto; }
         #cppcheckDetails td { white-space: normal; }
+        #cppcheckDetails .new { background-color: #FFC8C8; }
+        #cppcheckDetails .solved { background-color: #C8FFC8; }
+        #cppcheckDetails .unchanged { }
         </style>
 
         <table class="pane sortable" id="cppcheckDetails">
             <thead>
                 <tr>
+                    <td class="pane-header">${%State}</td>
                     <td class="pane-header">${%File}</td>
                     <td class="pane-header">${%Line}</td>
                     <td class="pane-header">${%Severity}</td>
@@ -23,9 +27,11 @@
                 </tr>
             </thead>
             <tbody>
-                <j:forEach var="elt" items="${cachedContainer.internalMap.values()}">
+                <j:forEach var="elt" items="${cachedContainer}">
                     <j:set var="cppcheckfile" value="${elt.cppcheckFile}"/>
-                    <tr>
+
+                    <tr class="${elt.diffState.css}">
+                        <td class="pane">${elt.diffState.text}</td>
                         <td class="pane">
                             <j:if test="${elt.isSourceIgnored()}">
                                 ${cppcheckfile.fileName}
@@ -36,10 +42,10 @@
                         </td>
                         <td class="pane">
                             <j:if test="${elt.isSourceIgnored()}">
-                                ${cppcheckfile.lineNumber}
+                                ${cppcheckfile.lineNumberString}
                             </j:if>
                             <j:if test="${not elt.isSourceIgnored()}">
-                                <a href="source.${cppcheckfile.key}#${cppcheckfile.linkLineNumber}">${cppcheckfile.lineNumber}</a>
+                                <a href="source.${cppcheckfile.key}#${cppcheckfile.linkLineNumber}">${cppcheckfile.lineNumberString}</a>
                             </j:if>
                         </td>
                         <td class="pane">${cppcheckfile.severity}</td>

--- a/src/main/resources/org/jenkinsci/plugins/cppcheck/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/cppcheck/Messages.properties
@@ -18,3 +18,7 @@ cppcheck.AllErrors=All errors
 
 cppcheck.BuildStability=Build stability for Cppcheck errors.
 cppcheck.PortletName=Cppcheck Statistics
+
+cppcheck.DiffNew=new
+cppcheck.DiffSolved=solved
+cppcheck.DiffUnchanged=unchanged


### PR DESCRIPTION
- A new column added to the report details table. It can contain "new", "solved" or "unchanged" flags to distinguish state of comparison with the previous report (if any). The column is mainly defined for an ability of sorting.
- "New" issues are additionally highlighted with red background, "solved" issues are green and "unchanged" has white color as usual.
- Solved issues also don't have the links to the source code, because it isn't available (issue was solved and the code is no longer present).
- New CppcheckDiffState enum/flag added and stored as transient in CppcheckWorkspaceFile class. It is a dynamic parameter that should not be saved to any XML file.
- The real comparison is done in CppcheckDiffState.diffCurrentAndPrevious().
- If source file is not available, no line will be displayed in the report (zero was present before).
