### PR TITLE
[JENKINS-22114] CPPCheck - when looking at the source code of an error -...

### DIFF
--- a/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/CppcheckSource.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/CppcheckSource.java
@@ -86,12 +86,13 @@ public class CppcheckSource implements Serializable {
     private void buildFileContent() {
         InputStream is = null;
         try {
-
             File tempFile = new File(cppcheckWorkspaceFile.getTempName(owner));
             if (tempFile.exists()) {
                 is = new FileInputStream(tempFile);
             } else {
-
+                // Reading real workspace file is more incorrect than correct,
+                // but the code is left here for backward compatibility with
+                // plugin version 1.14 and less
                 if (cppcheckWorkspaceFile.getFileName() == null) {
                     throw new IOException("The file doesn't exist.");
                 }

--- a/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/model/CppcheckWorkspaceFile.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/model/CppcheckWorkspaceFile.java
@@ -31,9 +31,9 @@ import java.io.File;
 
 public class CppcheckWorkspaceFile {
     /**
-     * Temporary directory holding the workspace files.
+     * Subdirectory of build directory to store the workspace files.
      */
-    public static final String WORKSPACE_FILES = "workspace-files";
+    public static final String DIR_WORKSPACE_FILES = "workspace-files";
 
     private String fileName;
 
@@ -100,7 +100,9 @@ public class CppcheckWorkspaceFile {
 
     public String getTempName(final AbstractBuild<?, ?> owner) {
         if (fileName != null) {
-            return owner.getRootDir().getAbsolutePath() + "/" + WORKSPACE_FILES + "/" + Integer.toHexString(fileName.hashCode()) + ".tmp";
+            return owner.getRootDir().getAbsolutePath() + "/"
+                    + DIR_WORKSPACE_FILES + "/"
+                    + Integer.toHexString(fileName.hashCode()) + ".tmp";
         }
         return StringUtils.EMPTY;
     }

--- a/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckPublisher.java
@@ -167,10 +167,8 @@ public class CppcheckPublisher extends Recorder {
                     XML_FILE_DETAILS));
             xmlSourceContainer.write(cppcheckSourceContainer);
 
-            if (build.getWorkspace().isRemote()) {
-                copyFilesFromSlaveToMaster(build.getRootDir(), launcher.getChannel(),
-                        cppcheckSourceContainer.getInternalMap().values());
-            }
+            copyFilesToBuildDirectory(build.getRootDir(), launcher.getChannel(),
+                    cppcheckSourceContainer.getInternalMap().values());
 
             CppcheckLogger.log(listener, "Ending the cppcheck analysis.");
         }
@@ -179,7 +177,7 @@ public class CppcheckPublisher extends Recorder {
 
 
     /**
-     * Copies all the source files from stave to master for a remote build.
+     * Copies all the source files from the workspace to the build folder.
      *
      * @param rootDir      directory to store the copied files in
      * @param channel      channel to get the files from
@@ -188,21 +186,15 @@ public class CppcheckPublisher extends Recorder {
      * @throws java.io.FileNotFoundException if the files could not be written
      * @throws InterruptedException          if the user cancels the processing
      */
-    private void copyFilesFromSlaveToMaster(final File rootDir,
+    private void copyFilesToBuildDirectory(final File rootDir,
             final VirtualChannel channel,
             final Collection<CppcheckWorkspaceFile> sourcesFiles)
             throws IOException, InterruptedException {
 
-        File directory = new File(rootDir, CppcheckWorkspaceFile.WORKSPACE_FILES);
-        if (!directory.exists()) {
-
-            if (!directory.delete()) {
-                //do nothing
-            }
-
-            if (!directory.mkdir()) {
-                throw new IOException("Can't create directory for remote source files: " + directory.getAbsolutePath());
-            }
+        File directory = new File(rootDir, CppcheckWorkspaceFile.DIR_WORKSPACE_FILES);
+        if (!directory.exists() && !directory.mkdir()) {
+            throw new IOException("Can't create directory for copy of workspace files: "
+                    + directory.getAbsolutePath());
         }
 
         for (CppcheckWorkspaceFile file : sourcesFiles) {


### PR DESCRIPTION
... the latest source is used
- The files with source code were copied to the build directory only for builds on slave machine. Builds on master didn't copied any file and workspace files (with all updates) were shown for historical builds too. The code updated to always copy all neccessary files to the build directory to provide the current code even after it is updated in future.
- Code for displaying of latest workspace files is still present, it is mainly for backward compatibility.
- Condition "if directory doesn't exist, _delete_ and create it" fixed - unneccessary/incorrect delete part removed.
