### PR TITLE
[JENKINS-22214] Fix findings from FindBugs static analysis

### DIFF
--- a/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/CppcheckMetricUtil.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/CppcheckMetricUtil.java
@@ -9,7 +9,7 @@ public class CppcheckMetricUtil {
         if (isValid(threshold)) {
             if (StringUtils.isNotBlank(threshold)) {
                 try {
-                    return Integer.valueOf(threshold);
+                    return Integer.parseInt(threshold);
                 } catch (NumberFormatException exception) {
                     // not valid
                 }
@@ -21,7 +21,7 @@ public class CppcheckMetricUtil {
     public static boolean isValid(final String threshold) {
         if (StringUtils.isNotBlank(threshold)) {
             try {
-                return Integer.valueOf(threshold) >= 0;
+                return Integer.parseInt(threshold) >= 0;
             } catch (NumberFormatException exception) {
                 // not valid
             }

--- a/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/CppcheckResult.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/CppcheckResult.java
@@ -70,7 +70,6 @@ public class CppcheckResult implements Serializable {
      *
      * @return the remote API
      */
-    @SuppressWarnings("unused")
     public Api getApi() {
         return new Api(report);
     }
@@ -80,12 +79,10 @@ public class CppcheckResult implements Serializable {
         return report;
     }
 
-    @SuppressWarnings("unused")
     public AbstractBuild<?, ?> getOwner() {
         return owner;
     }
 
-    @SuppressWarnings("unused")
     public CppcheckSourceContainer getCppcheckSourceContainer() {
         return cppcheckSourceContainer;
     }
@@ -99,7 +96,6 @@ public class CppcheckResult implements Serializable {
      * @return the dynamic result of the analysis (detail page).
      * @throws java.io.IOException if an error occurs
      */
-    @SuppressWarnings("unused")
     public Object getDynamic(final String link, final StaplerRequest request, final StaplerResponse response) throws IOException {
 
         if (link.startsWith("source.")) {
@@ -127,7 +123,6 @@ public class CppcheckResult implements Serializable {
      *
      * @return the HTML fragment of the summary Cppcheck report
      */
-    @SuppressWarnings("unused")
     public String getSummary() {
         return CppcheckSummary.createReportSummary(this);
     }
@@ -137,24 +132,8 @@ public class CppcheckResult implements Serializable {
      *
      * @return the HTML fragment of the summary Cppcheck report
      */
-    @SuppressWarnings("unused")
     public String getDetails() {
         return CppcheckSummary.createReportSummaryDetails(this);
-    }
-
-    /**
-     * Gets the previous Cppcheck report for the build result.
-     *
-     * @return the previous Cppcheck report
-     */
-    @SuppressWarnings("unused")
-    private CppcheckReport getPreviousReport() {
-        CppcheckResult previous = this.getPreviousResult();
-        if (previous == null) {
-            return null;
-        } else {
-            return previous.getReport();
-        }
     }
 
     /**

--- a/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/model/CppcheckSourceContainer.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/model/CppcheckSourceContainer.java
@@ -24,21 +24,23 @@
 package com.thalesgroup.hudson.plugins.cppcheck.model;
 
 import com.thalesgroup.hudson.plugins.cppcheck.util.CppcheckLogger;
+
 import hudson.FilePath;
 import hudson.model.BuildListener;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class CppcheckSourceContainer {
-
+public class CppcheckSourceContainer implements Serializable {
+    /** Serial version UID. */
+    private static final long serialVersionUID = 1L;
 
     private Map<Integer, CppcheckWorkspaceFile> internalMap = new HashMap<Integer, CppcheckWorkspaceFile>();
 
     public CppcheckSourceContainer(BuildListener listener, FilePath basedir, List<CppcheckFile> files) throws IOException, InterruptedException {
-
         int key = 1;
         for (CppcheckFile cppcheckFile : files) {
 
@@ -70,7 +72,6 @@ public class CppcheckSourceContainer {
             ++key;
         }
     }
-
 
     public Map<Integer, CppcheckWorkspaceFile> getInternalMap() {
         return internalMap;

--- a/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/model/CppcheckWorkspaceFile.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/model/CppcheckWorkspaceFile.java
@@ -24,12 +24,17 @@
 package com.thalesgroup.hudson.plugins.cppcheck.model;
 
 import hudson.model.AbstractBuild;
+
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.cppcheck.CppcheckDiffState;
 
 import java.io.File;
+import java.io.Serializable;
 
-public class CppcheckWorkspaceFile {
+public class CppcheckWorkspaceFile implements Serializable {
+    /** Serial version UID. */
+    private static final long serialVersionUID = 1L;
+
     /**
      * Subdirectory of build directory to store the workspace files.
      */

--- a/src/main/java/org/jenkinsci/plugins/cppcheck/config/CppcheckConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/config/CppcheckConfig.java
@@ -7,6 +7,8 @@ import java.io.Serializable;
  * @author Gregory Boissinot
  */
 public class CppcheckConfig implements Serializable {
+    /** Serial version UID. */
+    private static final long serialVersionUID = 1L;
 
     private String pattern;
     private boolean ignoreBlankFiles;

--- a/src/main/java/org/jenkinsci/plugins/cppcheck/config/CppcheckConfigGraph.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/config/CppcheckConfigGraph.java
@@ -6,6 +6,8 @@ import java.io.Serializable;
  * @author Gregory Boissinot
  */
 public class CppcheckConfigGraph implements Serializable {
+    /** Serial version UID. */
+    private static final long serialVersionUID = 1L;
 
     public static final int DEFAULT_CHART_WIDTH = 500;
     public static final int DEFAULT_CHART_HEIGHT = 200;

--- a/src/main/java/org/jenkinsci/plugins/cppcheck/config/CppcheckConfigSeverityEvaluation.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/config/CppcheckConfigSeverityEvaluation.java
@@ -6,6 +6,8 @@ import java.io.Serializable;
  * @author Gregory Boissinot
  */
 public class CppcheckConfigSeverityEvaluation implements Serializable {
+    /** Serial version UID. */
+    private static final long serialVersionUID = 1L;
 
     private String threshold;
 

--- a/src/main/java/org/jenkinsci/plugins/cppcheck/util/CppcheckMetricUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/util/CppcheckMetricUtil.java
@@ -10,7 +10,7 @@ public class CppcheckMetricUtil {
         if (isValid(threshold)) {
             if (StringUtils.isNotBlank(threshold)) {
                 try {
-                    return Integer.valueOf(threshold);
+                    return Integer.parseInt(threshold);
                 } catch (NumberFormatException exception) {
                     // not valid
                 }
@@ -22,7 +22,7 @@ public class CppcheckMetricUtil {
     public static boolean isValid(final String threshold) {
         if (StringUtils.isNotBlank(threshold)) {
             try {
-                return Integer.valueOf(threshold) >= 0;
+                return Integer.parseInt(threshold) >= 0;
             } catch (NumberFormatException exception) {
                 // not valid
             }

--- a/src/test/java/com/thalesgroup/hudson/plugins/cppcheck/AbstractWorkspaceTest.java
+++ b/src/test/java/com/thalesgroup/hudson/plugins/cppcheck/AbstractWorkspaceTest.java
@@ -43,6 +43,8 @@ public abstract class AbstractWorkspaceTest {
     }
 
     public void deleteWorkspace() throws Exception {
-        workspace.deleteRecursive();
+        if(workspace != null) {
+            workspace.deleteRecursive();
+        }
     }
 }

--- a/src/test/java/com/thalesgroup/hudson/plugins/cppcheck/CppcheckParserTest.java
+++ b/src/test/java/com/thalesgroup/hudson/plugins/cppcheck/CppcheckParserTest.java
@@ -94,7 +94,7 @@ public class CppcheckParserTest {
                                    int nbSeveritiesError,
                                    int nbSeveritiesNoCategory) throws Exception {
 
-        CppcheckReport cppcheckReport = cppcheckParser.parse(new File(this.getClass().getResource(filename).toURI()));
+        CppcheckReport cppcheckReport = cppcheckParser.parse(new File(CppcheckParserTest.class.getResource(filename).toURI()));
 
         List<CppcheckFile> everyErrors = cppcheckReport.getEverySeverities();
         List<CppcheckFile> possibileErrorSeverities = cppcheckReport.getPossibleErrorSeverities();

--- a/src/test/java/org/jenkinsci/plugins/cppcheck/CppcheckParserTest.java
+++ b/src/test/java/org/jenkinsci/plugins/cppcheck/CppcheckParserTest.java
@@ -36,7 +36,7 @@ public class CppcheckParserTest {
                                  int nbSeveritiesError,
                                  int nbSeveritiesNoCategory) throws Exception {
 
-        CppcheckReport cppcheckReport = cppcheckParser.parse(new File(this.getClass().getResource(filename).toURI()));
+        CppcheckReport cppcheckReport = cppcheckParser.parse(new File(CppcheckParserTest.class.getResource(filename).toURI()));
 
         List<CppcheckFile> everyErrors = cppcheckReport.getEverySeverities();
         List<CppcheckFile> possibileErrorSeverities = cppcheckReport.getPossibleErrorSeverities();


### PR DESCRIPTION
- CppcheckMetricUtil: A boxed primitive is created from a String, just to extract the unboxed primitive value. It is more efficient to just call the static parseXXX method.
- CppcheckResult: Private method com.thalesgroup.hudson.plugins.cppcheck.CppcheckResult.getPreviousReport() is never called.
- CppcheckResult: Class com.thalesgroup.hudson.plugins.cppcheck.CppcheckResult defines non-transient non-serializable instance field cppcheckSourceContainer.
- CppcheckSource: Class com.thalesgroup.hudson.plugins.cppcheck.CppcheckSource defines non-transient non-serializable instance field cppcheckWorkspaceFile.
- AbstractWorkspaceTest: AbstractWorkspaceTest.workspace not initialized in constructor and dereferenced in com.thalesgroup.hudson.plugins.cppcheck.AbstractWorkspaceTest.deleteWorkspace().
- CppcheckParserResultTestCppcheckParserResultTest: AbstractWorkspaceTest.workspace not initialized in constructor and dereferenced in com.thalesgroup.hudson.plugins.cppcheck.CppcheckParserResultTest.testNoMatch().
- CppcheckParserTest: Usage of GetResource in com.thalesgroup.hudson.plugins.cppcheck.CppcheckParserTest.processCheckstyle(String, int, int, int, int, int, int) may be unsafe if class is extended.
- serialVersionUID member variables defined in serializable classes.
- Unneccessary @SuppressWarnings("unused") removed to solve compiler warnings.
