### PR TITLE
[JENKINS-22388] Possible to move cppcheck summary into main job hudson p...

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckProjectAction.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckProjectAction.java
@@ -43,6 +43,16 @@ public class CppcheckProjectAction extends AbstractCppcheckProjectAction {
         return lastBuild;
     }
 
+    /**
+     * Get build action of the last finished build.
+     * 
+     * @return the build action or null
+     */
+    public CppcheckBuildAction getLastFinishedBuildAction() {
+        AbstractBuild<?, ?> lastBuild = getLastFinishedBuild();
+        return (lastBuild != null) ? lastBuild.getAction(CppcheckBuildAction.class) : null;
+    }
+
     public final boolean isDisplayGraph() {
         //Latest
         AbstractBuild<?, ?> b = getLastFinishedBuild();

--- a/src/main/java/org/jenkinsci/plugins/cppcheck/util/AbstractCppcheckProjectAction.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/util/AbstractCppcheckProjectAction.java
@@ -3,7 +3,7 @@ package org.jenkinsci.plugins.cppcheck.util;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Actionable;
-import hudson.model.ProminentProjectAction;
+import hudson.model.Action;
 
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -13,7 +13,7 @@ import java.io.IOException;
 /**
  * @author Gregory Boissinot
  */
-public abstract class AbstractCppcheckProjectAction extends Actionable implements ProminentProjectAction {
+public abstract class AbstractCppcheckProjectAction extends Actionable implements Action {
 
     protected final AbstractProject<?, ?> project;
 
@@ -26,7 +26,7 @@ public abstract class AbstractCppcheckProjectAction extends Actionable implement
     }
 
     public String getIconFileName() {
-        return "/plugin/cppcheck/icons/cppcheck-48.png";
+        return "/plugin/cppcheck/icons/cppcheck-24.png";
     }
 
     public String getSearchUrl() {

--- a/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckBuildAction/summary.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckBuildAction/summary.jelly
@@ -7,7 +7,7 @@
     xmlns:st="jelly:stapler">
 
     <t:summary icon="/plugin/cppcheck/icons/cppcheck-48.png">
-        <div><a href="cppcheckResult">${%Cppcheck}</a></div>
+        <div><a href="${it.urlName}">${it.displayName}</a></div>
         <j:set var="stat" value="${it.result.statistics}"/>
         <j:set var="diff" value="${it.result.diff}"/>
         <st:include page="statistics.jelly" />

--- a/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckProjectAction/jobMain.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckProjectAction/jobMain.jelly
@@ -1,0 +1,15 @@
+<j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson" xmlns:st="jelly:stapler">
+    <table style="margin-left:1em;">
+        <t:summary icon="/plugin/cppcheck/icons/cppcheck-48.png">
+            <div><a href="${it.urlName}">${it.displayName}</a></div>
+
+            <j:set var="lastBuildAction" value="${it.lastFinishedBuildAction}"/>
+            
+            <j:if test="${lastBuildAction != null}">
+                <j:set var="stat" value="${lastBuildAction.result.statistics}"/>
+                <j:set var="diff" value="${lastBuildAction.result.diff}"/>
+                <st:include page="/org/jenkinsci/plugins/cppcheck/CppcheckBuildAction/statistics.jelly"/>
+            </j:if>
+        </t:summary>
+    </table>
+</j:jelly>


### PR DESCRIPTION
...age?
- Project action updated to be standard Action instead of ProminentProjectAction.
- Icon from project action is now displayed only in the main menu on the left so correct 24px icon is used instead of 48px one. The larger icon was required by ProminentProjectAction that was rendered on top of the main page.
- Project action is now able to provide last build action. It is used in new jobMain.jelly that renders the statistics in the project action page.
- Build action summary uses urlName and displayName instead of the hardcoded strings.
