### PR TITLE
[JENKINS-18109] Show all violations highlighted on a single page

### DIFF
--- a/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/CppcheckSource.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/CppcheckSource.java
@@ -150,7 +150,7 @@ public class CppcheckSource implements Serializable {
         output.append("\">\n");
 
         output.append("<div tooltip=\"");
-        outputEscaped(output, cppcheckFile.getCppCheckId() + ":" + cppcheckFile.getMessage());
+        outputEscaped(output, cppcheckFile.getCppCheckId() + ": " + cppcheckFile.getMessage());
         output.append("\" nodismiss=\"\">\n");
         output.append("<code><b>\n");
 

--- a/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/model/CppcheckFile.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/model/CppcheckFile.java
@@ -24,6 +24,8 @@
 package com.thalesgroup.hudson.plugins.cppcheck.model;
 
 import hudson.model.ModelObject;
+
+import org.apache.commons.lang.StringEscapeUtils;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -103,6 +105,10 @@ public class CppcheckFile implements ModelObject, Serializable {
     @Exported
     public String getMessage() {
         return message;
+    }
+    
+    public String getMessageHtml() {
+        return StringEscapeUtils.escapeHtml(message);
     }
 
     public void setMessage(String message) {

--- a/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/model/CppcheckWorkspaceFile.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/model/CppcheckWorkspaceFile.java
@@ -103,18 +103,6 @@ public class CppcheckWorkspaceFile implements Serializable {
         return fileName;
     }
 
-    /**
-     * Returns the name of this file, allow wrap of long paths in a HTML page.
-     *
-     * @return the name of this file with <wbr /> element after each slash
-     */
-    public final String getFileNameHtmlWrap() {
-        if(fileName == null)
-            return "";
-
-        return fileName.replace("/", "/<wbr />");
-    }
-
     public String getTempName(final AbstractBuild<?, ?> owner) {
         if (fileName != null) {
             return owner.getRootDir().getAbsolutePath() + "/"

--- a/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckSourceAll.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckSourceAll.java
@@ -1,0 +1,143 @@
+package org.jenkinsci.plugins.cppcheck;
+
+import hudson.model.AbstractBuild;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Collection;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringEscapeUtils;
+
+import com.thalesgroup.hudson.plugins.cppcheck.model.CppcheckWorkspaceFile;
+
+/**
+ * Show all violations highlighted on a single page.
+ * 
+ * @author Michal Turek
+ * @since 1.16
+ */
+public class CppcheckSourceAll {
+    /** The related build. */
+    private final AbstractBuild<?, ?> owner;
+
+    /** The files to show. */
+    private final Collection<CppcheckWorkspaceFile> files;
+
+    /** Number of lines to show before the highlighted line. */
+    private final int linesBefore;
+
+    /** Number of lines to show after the highlighted line. */
+    private final int linesAfter;
+
+    /**
+     * Constructor.
+     * 
+     * @param owner
+     *            the related build
+     * @param files
+     *            the files to show
+     * @param linesBefore
+     *            number of lines to show before the highlighted line
+     * @param linesAfter
+     *            number of lines to show after the highlighted line
+     */
+    public CppcheckSourceAll(AbstractBuild<?, ?> owner,
+            Collection<CppcheckWorkspaceFile> files, int linesBefore,
+            int linesAfter) {
+        this.owner = owner;
+        this.files = files;
+        this.linesBefore = linesBefore;
+        this.linesAfter = linesAfter;
+    }
+
+    public AbstractBuild<?, ?> getOwner() {
+        return owner;
+    }
+
+    public Collection<CppcheckWorkspaceFile> getFiles() {
+        return files;
+    }
+
+    public int getLinesBefore() {
+        return linesBefore;
+    }
+
+    public int getLinesAfter() {
+        return linesAfter;
+    }
+
+    /**
+     * Get specified lines of source code from the file.
+     * 
+     * @param file
+     *            the input file
+     * @return the related lines of code with HTML formatting
+     */
+    public String getSourceCode(CppcheckWorkspaceFile file) {
+        File tempFile = new File(file.getTempName(owner));
+
+        if (!tempFile.exists()) {
+            return "Can't read file: " + tempFile.getAbsolutePath();
+        }
+
+        BufferedReader reader = null;
+
+        try {
+            reader = new BufferedReader(new FileReader(tempFile));
+            return getRelatedLines(reader, file.getCppcheckFile()
+                    .getLineNumber());
+        } catch (FileNotFoundException e) {
+            return "Can't read file: " + e;
+        } catch (IOException e) {
+            return "Reading file failed: " + e;
+        } finally {
+            IOUtils.closeQuietly(reader);
+        }
+    }
+
+    /**
+     * Get specified lines from a stream.
+     * 
+     * @param reader
+     *            the input stream
+     * @param lineNumber
+     *            the base line
+     * @return the lines with HTML formatting
+     * @throws IOException
+     *             if something fails
+     */
+    private String getRelatedLines(BufferedReader reader, int lineNumber)
+            throws IOException {
+        final int start = (lineNumber > linesBefore) ? lineNumber - linesBefore : 1;
+        final int end = lineNumber + linesAfter;
+        final String numberFormat = "%0" + String.valueOf(end).length() + "d";
+
+        StringBuilder builder = new StringBuilder();
+        int current = 1;
+        String line = "";
+
+        while ((line = reader.readLine()) != null && current <= end) {
+            if (current >= start) {
+                if (current == lineNumber) {
+                    builder.append("<div class=\"line highlighted\">");
+                } else {
+                    builder.append("<div class=\"line\">");
+                }
+
+                builder.append("<span class=\"lineNumber\">");
+                builder.append(String.format(numberFormat, current));
+                builder.append("</span> ");// The space separates line number and code
+                builder.append(StringEscapeUtils.escapeHtml(line));
+                builder.append("</div>\n");
+            }
+
+            ++current;
+        }
+
+        return builder.toString();
+    }
+}

--- a/src/main/resources/com/thalesgroup/hudson/plugins/cppcheck/CppcheckSource/index.jelly
+++ b/src/main/resources/com/thalesgroup/hudson/plugins/cppcheck/CppcheckSource/index.jelly
@@ -32,7 +32,7 @@
         <l:main-panel>
             <h1>${%Cppcheck Results}</h1>
 
-            <h2>${%sourcedetail.header(it.cppcheckWorkspaceFile.fileNameHtmlWrap)}</h2>
+            <h2>${%sourcedetail.header(it.cppcheckWorkspaceFile.cppcheckFile.fileName)}</h2>
 
             ${it.sourceCode}
         </l:main-panel>

--- a/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckResult/details.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckResult/details.jelly
@@ -3,58 +3,58 @@
 
     <j:set var="cachedContainer" value="${it.diffCurrentAndPrevious()}"/>
 
-    <j:if test="${cachedContainer != null}">
+    <h2>${%Details}</h2>
 
-        <h2>${%Details}</h2>
+    <style type="text/css">
+    #cppcheckDetails { width: auto; }
+    #cppcheckDetails td { white-space: normal; }
+    #cppcheckDetails .new { background-color: #FFC8C8; }
+    #cppcheckDetails .solved { background-color: #C8FFC8; }
+    #cppcheckDetails .unchanged { }
+    </style>
+    
+    <p><a href="source.all?before=5&amp;after=5">
+        ${%Show all violations highlighted on a single page.}
+    </a></p>
 
-        <style type="text/css">
-        #cppcheckDetails { width: auto; }
-        #cppcheckDetails td { white-space: normal; }
-        #cppcheckDetails .new { background-color: #FFC8C8; }
-        #cppcheckDetails .solved { background-color: #C8FFC8; }
-        #cppcheckDetails .unchanged { }
-        </style>
+    <table class="pane sortable" id="cppcheckDetails">
+        <thead>
+            <tr>
+                <td class="pane-header">${%State}</td>
+                <td class="pane-header">${%File}</td>
+                <td class="pane-header">${%Line}</td>
+                <td class="pane-header">${%Severity}</td>
+                <td class="pane-header">${%Type}</td>
+                <td class="pane-header">${%Message}</td>
+            </tr>
+        </thead>
+        <tbody>
+            <j:forEach var="elt" items="${cachedContainer}">
+                <j:set var="cppcheckFile" value="${elt.cppcheckFile}"/>
 
-        <table class="pane sortable" id="cppcheckDetails">
-            <thead>
-                <tr>
-                    <td class="pane-header">${%State}</td>
-                    <td class="pane-header">${%File}</td>
-                    <td class="pane-header">${%Line}</td>
-                    <td class="pane-header">${%Severity}</td>
-                    <td class="pane-header">${%Type}</td>
-                    <td class="pane-header">${%Message}</td>
+                <tr class="${elt.diffState.css}">
+                    <td class="pane">${elt.diffState.text}</td>
+                    <td class="pane">
+                        <j:if test="${elt.isSourceIgnored()}">
+                            ${cppcheckFile.fileName}
+                        </j:if>
+                        <j:if test="${not elt.isSourceIgnored()}">
+                            <a href="source.${cppcheckFile.key}">${cppcheckFile.fileName}</a>
+                        </j:if>
+                    </td>
+                    <td class="pane" data="${cppcheckFile.lineNumber}">
+                        <j:if test="${elt.isSourceIgnored()}">
+                            ${cppcheckFile.lineNumberString}
+                        </j:if>
+                        <j:if test="${not elt.isSourceIgnored()}">
+                            <a href="source.${cppcheckFile.key}#${cppcheckFile.linkLineNumber}">${cppcheckFile.lineNumberString}</a>
+                        </j:if>
+                    </td>
+                    <td class="pane">${cppcheckFile.severity}</td>
+                    <td class="pane">${cppcheckFile.cppCheckId}</td>
+                    <td class="pane">${cppcheckFile.messageHtml}</td>
                 </tr>
-            </thead>
-            <tbody>
-                <j:forEach var="elt" items="${cachedContainer}">
-                    <j:set var="cppcheckfile" value="${elt.cppcheckFile}"/>
-
-                    <tr class="${elt.diffState.css}">
-                        <td class="pane">${elt.diffState.text}</td>
-                        <td class="pane">
-                            <j:if test="${elt.isSourceIgnored()}">
-                                ${cppcheckfile.fileName}
-                            </j:if>
-                            <j:if test="${not elt.isSourceIgnored()}">
-                                <a href="source.${cppcheckfile.key}">${cppcheckfile.fileName}</a>
-                            </j:if>
-                        </td>
-                        <td class="pane" data="${cppcheckfile.lineNumber}">
-                            <j:if test="${elt.isSourceIgnored()}">
-                                ${cppcheckfile.lineNumberString}
-                            </j:if>
-                            <j:if test="${not elt.isSourceIgnored()}">
-                                <a href="source.${cppcheckfile.key}#${cppcheckfile.linkLineNumber}">${cppcheckfile.lineNumberString}</a>
-                            </j:if>
-                        </td>
-                        <td class="pane">${cppcheckfile.severity}</td>
-                        <td class="pane">${cppcheckfile.cppCheckId}</td>
-                        <td class="pane">${cppcheckfile.message}</td>
-                    </tr>
-                </j:forEach>
-            </tbody>
-        </table>
-
-    </j:if>
+            </j:forEach>
+        </tbody>
+    </table>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckSourceAll/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckSourceAll/index.jelly
@@ -1,0 +1,58 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+
+    <st:header name="Content-Type" value="text/html;charset=UTF-8"/>
+    <l:layout norefresh="true">
+        <st:include it="${it.owner}" page="sidepanel.jelly"/>
+
+        <l:main-panel>
+            <style type="text/css">
+            .cppcheck { padding: 1em; margin: 1em 0em 1em 0em; border: 1px solid silver; }
+            .newCppcheck { background-color: #FFC8C8; }
+            .solvedCppcheck { background-color: #C8FFC8; }
+            .unchangedCppcheck { }
+
+            .cppcheck h2 { margin-top: 0; }
+            .cppcheck code { display: block; margin: 1em 0em 1em 0em; }
+            .cppcheck .line { white-space: pre-wrap; }
+            .cppcheck .lineNumber { color: gray; }
+            .cppcheck .highlighted { line-height: 2.1em; background-color: #FCAF3E; font-weight: bold; }
+            </style>
+
+            <h1>${%Cppcheck Results}</h1>
+
+            <j:forEach var="file" items="${it.files}">
+                <div class="cppcheck ${file.diffState.css}Cppcheck">
+                    <h2>${file.cppcheckFile.messageHtml}</h2>
+
+                    <j:if test="${file.cppcheckFile.fileName != null}">
+                        <j:if test="${file.sourceIgnored}">
+                            <div>
+                                ${%Location:}
+                                ${file.cppcheckFile.fileName}:${file.cppcheckFile.lineNumber}
+                            </div>
+                        </j:if>
+                        <j:if test="${not file.sourceIgnored}">
+                            <div>
+                                ${%Location:}
+                                <a href="../source.${file.cppcheckFile.key}#${file.cppcheckFile.linkLineNumber}">
+                                    ${file.cppcheckFile.fileName}:${file.cppcheckFile.lineNumber}
+                                </a>
+                            </div>
+                        </j:if>
+                    </j:if>
+
+                    <div>${%State:} ${file.diffState.text}</div>
+                    <div>${%Severity:} ${file.cppcheckFile.severity}</div>
+                    <div>${%Type:} ${file.cppcheckFile.cppCheckId}</div>
+                    
+                    <j:if test="${not file.sourceIgnored}">
+                        <code>
+                            ${it.getSourceCode(file)}
+                        </code>
+                    </j:if>
+                </div>
+            </j:forEach>
+
+        </l:main-panel>
+    </l:layout>
+</j:jelly>


### PR DESCRIPTION
- New URL ".../cppcheckResult/source.all" points to a dynamic page rendered using a newly implemented class CppcheckSourceAll. Optional parameters are before=NUM and after=NUM to specify number of displayed lines, their default value is 5. A link was added above the table on the details page.
- Variable cppcheckfile refactored to cppcheckFile (f/F) to prevent copy-paste errors.
- Null check for return value of diffCurrentAndPrevious() removed, the method never returns null (found by FindBugs).
- Source details show only part of the path relative to the workspace in the header instead of the very long absolute path, the method getFileNameHtmlWrap() removed.
- Cppcheck message must be HTML escaped before passing to the page (e.g. "Comparison of a variable having boolean value using relational (<, >, <= or >=) operator.").
- Missing space added to the tooltip on the page with source code of a whole file.
- Annotations added to deprecated members present for backward compatibility.
