### PR TITLE
[JENKINS-11354] CppCheck plugin cannot find CppCheck report

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/cppcheck/parser/CppcheckParser.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/parser/CppcheckParser.java
@@ -53,9 +53,12 @@ public class CppcheckParser implements Serializable {
                 com.thalesgroup.jenkinsci.plugins.cppcheck.model.Results results = (com.thalesgroup.jenkinsci.plugins.cppcheck.model.Results) unmarshaller.unmarshal(file);
                 report = getReportVersion1(results);
             } catch (JAXBException jxe1) {
-                throw new IOException(jxe1);
-            }
+                // Since Java 1.6
+                // throw new IOException(jxe1);
 
+                // Legacy constructor for compatibility with Java 1.5
+                throw (IOException) new IOException(jxe1.toString()).initCause(jxe1);
+            }
         }
         return report;
     }


### PR DESCRIPTION
[JENKINS-22823] Cppcheck plugin can't connect to report file
- Constructor IOException(Throwable cause) was introduced in Java 1.6 and is not compatible with Java 1.5.

FATAL: java.io.IOException: method <init>(Ljava/lang/Throwable;)V not found
java.lang.NoSuchMethodError: java.io.IOException: method <init>(Ljava/lang/Throwable;)V not found
at org.jenkinsci.plugins.cppcheck.parser.CppcheckParser.parse(CppcheckParser.java:56)
