### PR TITLE
[JENKINS-23185] Setting build status to FAILURE for new error when error...

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/cppcheck/util/CppcheckBuildResultEvaluator.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/util/CppcheckBuildResultEvaluator.java
@@ -17,33 +17,42 @@ public class CppcheckBuildResultEvaluator {
             CppcheckConfigSeverityEvaluation severityEvaluation) {
 
         if (isErrorCountExceeded(errorsCount, severityEvaluation.getFailureThreshold())) {
-            CppcheckLogger.log(listener, "Setting build status to FAILURE since total number of errors"
-                    + " exceeds the threshold value '" + severityEvaluation.getFailureThreshold() + "'.");
+            CppcheckLogger.log(listener,
+                    "Setting build status to FAILURE since total number of issues '"
+                            + errorsCount + "' exceeds the threshold value '"
+                            + severityEvaluation.getFailureThreshold() + "'.");
             return Result.FAILURE;
         }
         if (isErrorCountExceeded(newErrorsCount, severityEvaluation.getNewFailureThreshold())) {
-            CppcheckLogger.log(listener, "Setting build status to FAILURE since total number of new errors"
-                    + " exceeds the threshold value '" + severityEvaluation.getNewFailureThreshold() + "'.");
+            CppcheckLogger.log(listener,
+                    "Setting build status to FAILURE since number of new issues '"
+                            + newErrorsCount + "' exceeds the threshold value '"
+                            + severityEvaluation.getNewFailureThreshold() + "'.");
             return Result.FAILURE;
         }
         if (isErrorCountExceeded(errorsCount, severityEvaluation.getThreshold())) {
-            CppcheckLogger.log(listener, "Setting build status to UNSTABLE since total number of errors"
-                    + " exceeds the threshold value '" + severityEvaluation.getThreshold() + "'.");
+            CppcheckLogger.log(listener,
+                    "Setting build status to UNSTABLE since total number of issues '"
+                            + errorsCount + "' exceeds the threshold value '"
+                            + severityEvaluation.getThreshold() + "'.");
             return Result.UNSTABLE;
         }
         if (isErrorCountExceeded(newErrorsCount, severityEvaluation.getNewThreshold())) {
-            CppcheckLogger.log(listener, "Setting build status to UNSTABLE since total number of new errors"
-                    + " exceeds the threshold value '" + severityEvaluation.getNewThreshold() + "'.");
+            CppcheckLogger.log(listener,
+                    "Setting build status to UNSTABLE since number of new issues '"
+                            + newErrorsCount + "' exceeds the threshold value '"
+                            + severityEvaluation.getNewThreshold() + "'.");
             return Result.UNSTABLE;
         }
 
-        CppcheckLogger.log(listener, "Not changing build status, since no threshold has been exceeded");
+        CppcheckLogger.log(listener,
+                "Not changing build status, since no threshold has been exceeded.");
         return Result.SUCCESS;
     }
 
     private boolean isErrorCountExceeded(final int errorCount, final String errorThreshold) {
         if (errorCount > 0 && CppcheckMetricUtil.isValid(errorThreshold)) {
-            return errorCount > CppcheckMetricUtil.convert(errorThreshold);
+            return errorCount >= CppcheckMetricUtil.convert(errorThreshold);
         }
         return false;
     }


### PR DESCRIPTION
...s were fixed
- CppcheckBuildResultEvaluator.isErrorCountExceeded() used comparison count > threshold but users expect count >= threshold.
- For example the threshold had to be set to 0 to change build status on 1 new issue. Setting 1 in threshold configuration to detect 1 issue is much better.
- Information in build log extended to contain also the value that exceeded the threshold. Word "errors" replaced by "issues".
