### PR TITLE
[JENKINS-23888] Add query parameter support for filtering errors based o...

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckDiffState.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckDiffState.java
@@ -3,10 +3,10 @@ package org.jenkinsci.plugins.cppcheck;
 /**
  * Status of comparison of two reports.
  * 
- * Implementation note: The declaration order of the constants is significant,
- * it's used in sorting.
+ * Implementation note: The upper case of the constants and declaration order
+ * are significant, the second one is used in sorting.
  * 
- * @see CppcheckResult#diffCurrentAndPrevious()
+ * @see CppcheckResult#diffCurrentAndPrevious(java.util.Set)
  * @author Michal Turek
  */
 public enum CppcheckDiffState {

--- a/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckResult/details.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckResult/details.jelly
@@ -1,7 +1,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:g="/jelly/cppcheck">
     <st:header name="Content-Type" value="text/html;charset=UTF-8"/>
 
-    <j:set var="cachedContainer" value="${it.diffCurrentAndPrevious()}"/>
+    <j:set var="cachedContainer" value="${it.diffCurrentAndPrevious(null)}"/>
 
     <h2>${%Details}</h2>
 
@@ -13,10 +13,15 @@
     #cppcheckDetails .unchanged { }
     #cppcheckDetails .inconclusive { color: #555555; }
     </style>
-    
-    <p><a href="source.all?before=5&amp;after=5">
-        ${%Show all violations highlighted on a single page.}
-    </a></p>
+
+    <p>Show issues highlighted on a single page</p>
+    <ul>
+        <li><a href="source.all?before=5&amp;after=5">${%all}</a></li>
+        <li><a href="source.all?before=5&amp;after=5&amp;states=new,solved">${%new and solved}</a></li>
+        <li><a href="source.all?before=5&amp;after=5&amp;states=new">${%new}</a></li>
+        <li><a href="source.all?before=5&amp;after=5&amp;states=solved">${%solved}</a></li>
+        <li><a href="source.all?before=5&amp;after=5&amp;states=unchanged">${%unchanged}</a></li>
+    </ul>
 
     <table class="pane sortable" id="cppcheckDetails">
         <thead>

--- a/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckSourceAll/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckSourceAll/index.jelly
@@ -23,6 +23,10 @@
 
             <h1>${%Cppcheck Results}</h1>
 
+            <j:if test="${it.files.isEmpty()}">
+                <p>${%The result set is empty.}</p>
+            </j:if>
+
             <j:forEach var="file" items="${it.files}">
                 <j:set var="inconclusiveCss" value=""/>
                 <j:if test="${file.cppcheckFile.inconclusive}">


### PR DESCRIPTION
...n new, resolved or unchanged
- New optional "states" parameter added to cppcheckResult/source.all page.
- It's a comma separated filter with states to include to the output (e.g. "?states=new,solved").
