### PR TITLE
[JENKINS-24076] Add a configuration option for stable build comparison

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckPublisher.java
@@ -42,6 +42,7 @@ public class CppcheckPublisher extends Recorder {
     public CppcheckPublisher(String pattern,
                              boolean ignoreBlankFiles, String threshold,
                              boolean allowNoReport,
+                             boolean stableBuild,
                              String newThreshold, String failureThreshold,
                              String newFailureThreshold, String healthy, String unHealthy,
                              boolean severityError,
@@ -66,6 +67,7 @@ public class CppcheckPublisher extends Recorder {
         cppcheckConfig.setPattern(pattern);
         cppcheckConfig.setAllowNoReport(allowNoReport);
         cppcheckConfig.setIgnoreBlankFiles(ignoreBlankFiles);
+        cppcheckConfig.setStableBuild(stableBuild);
         CppcheckConfigSeverityEvaluation configSeverityEvaluation = new CppcheckConfigSeverityEvaluation(
                 threshold, newThreshold, failureThreshold, newFailureThreshold, healthy, unHealthy,
                 severityError,
@@ -143,7 +145,8 @@ public class CppcheckPublisher extends Recorder {
                     = new CppcheckSourceContainer(listener, build.getWorkspace(),
                             build.getModuleRoot(), cppcheckReport.getAllErrors());
 
-            CppcheckResult result = new CppcheckResult(cppcheckReport.getStatistics(), build);
+            CppcheckResult result = new CppcheckResult(cppcheckReport.getStatistics(), build, 
+            		cppcheckConfig.getStableBuild());
             CppcheckConfigSeverityEvaluation severityEvaluation
                     = cppcheckConfig.getConfigSeverityEvaluation();
 

--- a/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckResult.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckResult.java
@@ -54,6 +54,13 @@ public class CppcheckResult implements Serializable {
      * @since 1.15
      */
     private CppcheckStatistics statistics;
+    
+    /**
+     * Use stable builds only.
+     * 
+     * @since 1.20
+     */
+    private boolean stableBuild;
 
     /**
      * Constructor.
@@ -68,6 +75,25 @@ public class CppcheckResult implements Serializable {
     public CppcheckResult(CppcheckStatistics statistics, AbstractBuild<?, ?> owner) {
         this.statistics = statistics;
         this.owner = owner;
+        this.stableBuild = false;
+    }
+    
+    /**
+     * Constructor.
+     * 
+     * @param statistics
+     *            the Cppcheck report statistics
+     * @param owner
+     *            the build owner
+     * @param stableBuild
+     * 	          use only stable builds for deltas
+     * 
+     * @since 1.15
+     */
+    public CppcheckResult(CppcheckStatistics statistics, AbstractBuild<?, ?> owner, boolean stableBuild) {
+        this.statistics = statistics;
+        this.owner = owner;
+        this.stableBuild = stableBuild;
     }
     
     /**
@@ -230,6 +256,14 @@ public class CppcheckResult implements Serializable {
      */
     private CppcheckBuildAction getPreviousAction() {
         AbstractBuild<?, ?> previousBuild = owner.getPreviousBuild();
+        
+        if (this.stableBuild) {
+        	// Iterate the build chain and find the last successful build.
+        	while (null != previousBuild && previousBuild.getResult().isWorseThan(hudson.model.Result.SUCCESS)) {
+        		previousBuild = previousBuild.getPreviousBuild();
+        	}
+        }
+        
         if (previousBuild != null) {
             return previousBuild.getAction(CppcheckBuildAction.class);
         }

--- a/src/main/java/org/jenkinsci/plugins/cppcheck/config/CppcheckConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/config/CppcheckConfig.java
@@ -13,6 +13,7 @@ public class CppcheckConfig implements Serializable {
     private String pattern;
     private boolean ignoreBlankFiles;
     private boolean allowNoReport;
+    private boolean stableBuild;
     private CppcheckConfigSeverityEvaluation configSeverityEvaluation = new CppcheckConfigSeverityEvaluation();
     private CppcheckConfigGraph configGraph = new CppcheckConfigGraph();
 
@@ -26,6 +27,10 @@ public class CppcheckConfig implements Serializable {
 
     public void setAllowNoReport(boolean allowNoReport) {
         this.allowNoReport = allowNoReport;
+    }
+    
+    public void setStableBuild(boolean stableBuild) {
+    	this.stableBuild = stableBuild;
     }
 
     public void setConfigSeverityEvaluation(CppcheckConfigSeverityEvaluation configSeverityEvaluation) {
@@ -63,6 +68,10 @@ public class CppcheckConfig implements Serializable {
 
     public boolean getAllowNoReport() {
         return allowNoReport;
+    }
+
+    public boolean getStableBuild() {
+        return stableBuild;
     }
 
     public CppcheckConfigSeverityEvaluation getConfigSeverityEvaluation() {

--- a/src/main/resources/com/thalesgroup/hudson/plugins/cppcheck/CppcheckPublisher/config.properties
+++ b/src/main/resources/com/thalesgroup/hudson/plugins/cppcheck/CppcheckPublisher/config.properties
@@ -3,5 +3,5 @@ description.pattern=Cppcheck must be configured to generate XML reports for this
 setting that specifies the generated cppcheck XML report files, such as '**/cppcheck-result-*.xml'. \
 Basedir of the fileset is relative to the workspace root. \
 If no value is set, then the default '**/cppcheck-result.xml' is used. Be sure not to include any \
-non-report files into this pattern.\	
+non-report files into this pattern.\
     		 		

--- a/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckPublisher/config.jelly
@@ -19,6 +19,11 @@
         <label>${%Do not fail the build if the Cppcheck report is not found}</label>
     </f:entry>
 
+    <f:entry field="stableBuild">
+        <f:checkbox name="cppcheck.stableBuild" checked="${config.stableBuild}"/>
+        <label>${%Compare the Cppcheck report to the last stable build's Cppcheck report}</label>
+    </f:entry>
+
     <f:advanced>
         <u:thresholds id="cppcheck"/>
     </f:advanced>

--- a/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckPublisher/help-stableBuild.html
+++ b/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckPublisher/help-stableBuild.html
@@ -1,0 +1,12 @@
+<p style="margin-top: 0px;">By default, Cppcheck compares the report warnings 
+and errors to that of the last build, which could be a build that was deemed 
+unstable or that failed.  To compare the results of this build against the last 
+"stable" build instead, check this option.</p>
+
+<p>Note: When comparing against unstable builds, your builds could be marked as 
+stable even when new errors or warnings have been introduced, because the delta 
+between the last unstable build and current build could be zero.  If the 
+unstable build introduced a new error but resolve an error, then the total 
+error count will still be within the permitted threshold. Another build with 
+the same results will be marked as stable, allowing the new error to go 
+unnoticed.  Selecting this option will ensure all errors are accounted for.</p>


### PR DESCRIPTION
Add a configuration option for Cppcheck to compare results against a stable build rather than the last
build.
