### PR TITLE
[JENKINS-24834] CPP check report background colours not displaying for n...

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckResult/details.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckResult/details.jelly
@@ -44,9 +44,9 @@
                     <j:set var="inconclusiveCss" value="inconclusive"/>
                 </j:if>
 
-                <tr class="${elt.diffState.css} ${inconclusiveCss}">
-                    <td class="pane">${elt.diffState.text}</td>
-                    <td class="pane">
+                <tr>
+                    <td class="pane ${elt.diffState.css} ${inconclusiveCss}">${elt.diffState.text}</td>
+                    <td class="pane ${elt.diffState.css} ${inconclusiveCss}">
                         <j:if test="${elt.isSourceIgnored()}">
                             ${cppcheckFile.fileName}
                         </j:if>
@@ -54,7 +54,7 @@
                             <a href="source.${cppcheckFile.key}">${cppcheckFile.fileName}</a>
                         </j:if>
                     </td>
-                    <td class="pane" data="${cppcheckFile.lineNumber}">
+                    <td class="pane ${elt.diffState.css} ${inconclusiveCss}" data="${cppcheckFile.lineNumber}">
                         <j:if test="${elt.isSourceIgnored()}">
                             ${cppcheckFile.lineNumberString}
                         </j:if>
@@ -62,10 +62,10 @@
                             <a href="source.${cppcheckFile.key}#${cppcheckFile.linkLineNumber}">${cppcheckFile.lineNumberString}</a>
                         </j:if>
                     </td>
-                    <td class="pane">${cppcheckFile.severity}</td>
-                    <td class="pane">${cppcheckFile.cppCheckId}</td>
-                    <td class="pane">${cppcheckFile.inconclusive}</td>
-                    <td class="pane">${cppcheckFile.messageHtml}</td>
+                    <td class="pane ${elt.diffState.css} ${inconclusiveCss}">${cppcheckFile.severity}</td>
+                    <td class="pane ${elt.diffState.css} ${inconclusiveCss}">${cppcheckFile.cppCheckId}</td>
+                    <td class="pane ${elt.diffState.css} ${inconclusiveCss}">${cppcheckFile.inconclusive}</td>
+                    <td class="pane ${elt.diffState.css} ${inconclusiveCss}">${cppcheckFile.messageHtml}</td>
                 </tr>
             </j:forEach>
         </tbody>

--- a/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckResult/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckResult/index.jelly
@@ -1,5 +1,5 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
-    <l:layout norefresh="true">
+    <l:layout norefresh="true" title="${%Cppcheck Results}">
         <st:include it="${it.owner}" page="sidepanel.jelly"/>
         <l:main-panel>
 

--- a/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckSourceAll/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/cppcheck/CppcheckSourceAll/index.jelly
@@ -1,7 +1,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
 
     <st:header name="Content-Type" value="text/html;charset=UTF-8"/>
-    <l:layout norefresh="true">
+    <l:layout norefresh="true" title="${%Cppcheck Results}">
         <st:include it="${it.owner}" page="sidepanel.jelly"/>
 
         <l:main-panel>


### PR DESCRIPTION
...ew or resolved issues since upgrade
- White background color was set to all TD elements in core's JENKINS-24625 which overwrote settings of outer TR.
- Missing mandatory "title" element added to l:layout.
