### PR TITLE
Fix "new errors" bug.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckPublisher.java
@@ -149,7 +149,7 @@ public class CppcheckPublisher extends Recorder {
                     = new CppcheckSourceContainer(listener, build.getWorkspace(),
                             build.getModuleRoot(), cppcheckReport.getAllErrors());
 
-            CppcheckResult result = new CppcheckResult(cppcheckReport.getStatistics(), build);
+            CppcheckResult result = new CppcheckResult(cppcheckReport.getStatistics(), build, cppcheckSourceContainer);
             CppcheckConfigSeverityEvaluation severityEvaluation
                     = cppcheckConfig.getConfigSeverityEvaluation();
 

--- a/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckResult.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckResult.java
@@ -25,6 +25,8 @@ import java.util.*;
  */
 public class CppcheckResult implements Serializable {
     private static final long serialVersionUID = 2L;
+    
+    private int newFailures = 0;
 
     /**
      * The Cppcheck report.
@@ -68,6 +70,26 @@ public class CppcheckResult implements Serializable {
     public CppcheckResult(CppcheckStatistics statistics, AbstractBuild<?, ?> owner) {
         this.statistics = statistics;
         this.owner = owner;
+    }
+    
+    /**
+     * Alternate Constructor.
+     * 
+     * @param statistics
+     *            the Cppcheck report statistics
+     * @param owner
+     *            the build owner
+     *            
+     * @param CppcheckSourcesContainer
+     * 			  Container for check results
+     * 
+     * Added to enable "new errors" to work off all new errors instead of the sum. 
+     */
+    
+    public CppcheckResult(CppcheckStatistics statistics, AbstractBuild<?, ?> owner, CppcheckSourceContainer cppcheckSourceContainer) {
+        this.statistics = statistics;
+        this.owner = owner;
+        this.cppcheckSourceContainer = cppcheckSourceContainer;
     }
     
     /**
@@ -344,8 +366,9 @@ public class CppcheckResult implements Serializable {
 
         if (checkNewError) {
             if (previousResult != null) {
-                return nbErrors - nbPreviousError;
-            } else {
+            	diffCurrentAndPrevious(null);
+            	return this.newFailures; 
+            	} else {
                 return 0;
             }
         } else {
@@ -367,6 +390,7 @@ public class CppcheckResult implements Serializable {
      */
     public Collection<CppcheckWorkspaceFile> diffCurrentAndPrevious(
             Set<CppcheckDiffState> filter) {
+    	this.newFailures = 0; 
         CppcheckSourceContainer cur = getCppcheckSourceContainer();
         CppcheckResult prevResult = getPreviousResult();
         List<CppcheckWorkspaceFile> curValues
@@ -429,6 +453,7 @@ public class CppcheckResult implements Serializable {
             if(curFile.getDiffState() != null) {
                 continue;
             }
+            this.newFailures += 1; 
 
             curFile.setDiffState(CppcheckDiffState.NEW);
         }


### PR DESCRIPTION
Fixes the "new errors" count being a diff instead of pinging off every new error.

Calls "diffCurrentAndPrevious" if there was a job before to determine if any errors are considered "new".  Will then return that count as the count of new errors.

Should resolve bug; https://issues.jenkins-ci.org/browse/JENKINS-25214?src=confmacro