### PR TITLE
Update pom.xml to inject repositories of dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,20 @@
 	<jenkins.version>2.30</jenkins.version>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
 
         <dependency>


### PR DESCRIPTION
It seems jenkins's ci maven job doesn't define them in its settings.