### PR TITLE
Allow for publishing Cppcheck results for FAILED builds

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckPublisher.java
@@ -53,7 +53,7 @@ public class CppcheckPublisher extends Recorder implements SimpleBuildStep {
     private CppcheckConfig cppcheckConfig;
 
     @DataBoundConstructor
-    public CppcheckPublisher() {this("", false, "", false, "", "", "", "", "", true, true, true, true, true, true, true, 500, 200, 0, true, false, false, false, false, false, false, false);}
+    public CppcheckPublisher() {this("", false, "", false, "", "", "", "", "", true, true, true, true, true, true, true, 500, 200, 0, true, false, false, false, false, false, false, false, false, false);}
 
     @Deprecated
     public CppcheckPublisher(String pattern,
@@ -77,12 +77,16 @@ public class CppcheckPublisher extends Recorder implements SimpleBuildStep {
                              boolean displayPerformanceSeverity,
                              boolean displayInformationSeverity,
                              boolean displayNoCategorySeverity,
-                             boolean displayPortabilitySeverity) {
+                             boolean displayPortabilitySeverity,
+                             boolean ignoreBuildResult,
+                             boolean dontUpdateBuildResult) {
 
         config = new CppcheckConfig();
 
         config.setPattern(pattern);
         config.setAllowNoReport(allowNoReport);
+        config.setIgnoreBuildResult(ignoreBuildResult);
+        config.setDontUpdateBuildResult(dontUpdateBuildResult);
         config.setIgnoreBlankFiles(ignoreBlankFiles);
         CppcheckConfigSeverityEvaluation configSeverityEvaluation = new CppcheckConfigSeverityEvaluation(
                 threshold, newThreshold, failureThreshold, newFailureThreshold, healthy, unHealthy,
@@ -180,6 +184,20 @@ public class CppcheckPublisher extends Recorder implements SimpleBuildStep {
     }
     public boolean getAllowNoReport() {
         return config.getAllowNoReport();
+    }
+    @DataBoundSetter
+    public void setIgnoreBuildResult(boolean ignoreBuildResult) {
+        config.setIgnoreBuildResult(ignoreBuildResult);
+    }
+    public boolean getIgnoreBuildResult() {
+        return config.getIgnoreBuildResult();
+    }
+    @DataBoundSetter
+    public void setDontUpdateBuildResult(boolean dontUpdateBuildResult) {
+        config.setDontUpdateBuildResult(dontUpdateBuildResult);
+    }
+    public boolean getDontUpdateBuildResult() {
+        return config.getDontUpdateBuildResult();
     }
     @DataBoundSetter
     public void setSeverityError(boolean severityError) {
@@ -312,7 +330,7 @@ public class CppcheckPublisher extends Recorder implements SimpleBuildStep {
     }
 
     protected boolean canContinue(final Result result) {
-        return result != Result.ABORTED && result != Result.FAILURE;
+        return (config.getIgnoreBuildResult() || result != Result.ABORTED && result != Result.FAILURE);
     }
 
     public BuildStepMonitor getRequiredMonitorService() {
@@ -364,7 +382,7 @@ public class CppcheckPublisher extends Recorder implements SimpleBuildStep {
                         result.getNumberErrorsAccordingConfiguration(severityEvaluation, true),
                         severityEvaluation);
 
-                if (buildResult != Result.SUCCESS) {
+                if (config.getDontUpdateBuildResult() || buildResult != Result.SUCCESS) {
                     build.setResult(buildResult);
                 }
 
@@ -435,7 +453,7 @@ public class CppcheckPublisher extends Recorder implements SimpleBuildStep {
                     result.getNumberErrorsAccordingConfiguration(severityEvaluation, true),
                     severityEvaluation);
 
-            if (buildResult != Result.SUCCESS) {
+            if (config.getDontUpdateBuildResult() || buildResult != Result.SUCCESS) {
                 build.setResult(buildResult);
             }
 

--- a/src/main/java/org/jenkinsci/plugins/cppcheck/config/CppcheckConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/config/CppcheckConfig.java
@@ -14,6 +14,8 @@ public class CppcheckConfig implements Serializable {
     private String pattern;
     private boolean ignoreBlankFiles;
     private boolean allowNoReport;
+    private boolean ignoreBuildResult;
+    private boolean dontUpdateBuildResult;
     private CppcheckConfigSeverityEvaluation configSeverityEvaluation = new CppcheckConfigSeverityEvaluation();
     private CppcheckConfigGraph configGraph = new CppcheckConfigGraph();
 
@@ -30,6 +32,17 @@ public class CppcheckConfig implements Serializable {
     public void setAllowNoReport(boolean allowNoReport) {
         this.allowNoReport = allowNoReport;
     }
+
+    @DataBoundSetter
+    public void setIgnoreBuildResult(boolean ignoreBuildResult) {
+        this.ignoreBuildResult = ignoreBuildResult;
+    }
+
+    @DataBoundSetter
+    public void setDontUpdateBuildResult(boolean dontUpdateBuildResult) {
+        this.dontUpdateBuildResult = dontUpdateBuildResult;
+    }
+
     @DataBoundSetter
     public void setConfigSeverityEvaluation(CppcheckConfigSeverityEvaluation configSeverityEvaluation) {
         this.configSeverityEvaluation = configSeverityEvaluation;
@@ -69,6 +82,14 @@ public class CppcheckConfig implements Serializable {
 
     public boolean getAllowNoReport() {
         return allowNoReport;
+    }
+
+    public boolean getIgnoreBuildResult() {
+        return ignoreBuildResult;
+    }
+
+    public boolean getDontUpdateBuildResult() {
+        return dontUpdateBuildResult;
     }
 
     public CppcheckConfigSeverityEvaluation getConfigSeverityEvaluation() {


### PR DESCRIPTION
This commit adds two extra parameters to `publishCppcheck`:

`ignoreBuildResult [boolean]`

Skip any build result checks and publish Cppcheck results any way.

`dontUpdateBuildResult [boolean]`

This does not change the current build result based on Cppcheck results. This is useful if you want to handle the build result by yourself.