### PR TITLE
[JENKINS-59021] Calculate diff against any other cppcheck result

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,6 @@ Cppcheck Plugin
 
 This [Jenkins CI](http://jenkins-ci.org/) plug-in generates the trend report for [Cppcheck](http://cppcheck.sourceforge.net/), a tool for static C/C++ code analysis.
 
+To setup your environment for development of this plugin, see the "Setting up a productive environment with your IDE" part of: <https://wiki.jenkins.io/display/JENKINS/Plugin+tutorial#Plugintutorial-Eclipse>
+
 For more information, visit the wiki page <https://wiki.jenkins-ci.org/display/JENKINS/Cppcheck+Plugin>.

--- a/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckPublisher.java
@@ -426,9 +426,13 @@ public class CppcheckPublisher extends Recorder implements SimpleBuildStep {
                 }
             }
             
+            FilePath workspace = build.getWorkspace();
+            FilePath moduleRoot = build.getModuleRoot();
+            		
+            
             CppcheckSourceContainer cppcheckSourceContainer
-                    = new CppcheckSourceContainer(listener, build.getWorkspace(),
-                            build.getModuleRoot(), cppcheckReport.getAllErrors());
+                    = new CppcheckSourceContainer(listener, workspace,
+                            moduleRoot, cppcheckReport.getAllErrors());
 
             CppcheckResult result = new CppcheckResult(cppcheckReport.getStatistics(), build);
             result.setSourceContainerPath(XML_FILE_DETAILS);
@@ -458,7 +462,7 @@ public class CppcheckPublisher extends Recorder implements SimpleBuildStep {
 			* If config has a baseline pattern (optional), do the required parsing,
 			* report creation and writing to the build directory
 			*/
-            if(config.isHasBaselinePattern()) {
+            if(config.isHasBaselinePattern() && workspace != null && moduleRoot != null) {
             	CppcheckReport cppcheckBaselineReport = generateCppcheckReport(build, listener, config.getBaselinePattern());
 				
 				if (cppcheckBaselineReport != null) {
@@ -468,8 +472,8 @@ public class CppcheckPublisher extends Recorder implements SimpleBuildStep {
 					result.setBaselineResult(new CppcheckResult(cppcheckBaselineReport.getStatistics(), build));
 					
 					CppcheckSourceContainer cppcheckBaselineSourceContainer = new CppcheckSourceContainer(listener, 
-							build.getWorkspace().withSuffix(BASELINE_SUBDIRECTORY), 
-							build.getModuleRoot().withSuffix(BASELINE_SUBDIRECTORY), 
+							workspace.withSuffix(BASELINE_SUBDIRECTORY), 
+							moduleRoot.withSuffix(BASELINE_SUBDIRECTORY), 
 							cppcheckBaselineReport.getAllErrors());
 					
 					writeAndCopyXmlFiles(build.getRootDir(), BASELINE_SUBDIRECTORY, launcher, baselineResult.getSourceContainerPath(),
@@ -553,13 +557,16 @@ public class CppcheckPublisher extends Recorder implements SimpleBuildStep {
     	
     	XmlFile xmlSourceContainer = new XmlFile(new File(rootDir, sourceContainerPath));
     	xmlSourceContainer.write(sourceContainer);
+    	boolean allDirectoriesExist = rootDir.isDirectory();
     	
     	if (child != null) {
     		rootDir = new File(rootDir, child);
-    		rootDir.mkdirs();
+    		allDirectoriesExist = rootDir.mkdirs();
     	}
     	
-    	copyFilesToBuildDirectory(rootDir, launcher.getChannel(), sourceContainer.getInternalMap().values());
+    	if(allDirectoriesExist) {
+    		copyFilesToBuildDirectory(rootDir, launcher.getChannel(), sourceContainer.getInternalMap().values());
+    	}
     	
     }
 

--- a/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckResult.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/CppcheckResult.java
@@ -49,7 +49,7 @@ public class CppcheckResult implements Serializable {
     /**
      * The build owner.
      */
-    private Run<?, ?> owner;
+    private transient Run<?, ?> owner;
 
     /**
      * The Cppcheck report statistics.

--- a/src/main/java/org/jenkinsci/plugins/cppcheck/config/CppcheckConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/config/CppcheckConfig.java
@@ -12,6 +12,7 @@ public class CppcheckConfig implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private String pattern;
+    private String baselinePattern;
     private boolean ignoreBlankFiles;
     private boolean allowNoReport;
     private CppcheckConfigSeverityEvaluation configSeverityEvaluation = new CppcheckConfigSeverityEvaluation();
@@ -20,6 +21,11 @@ public class CppcheckConfig implements Serializable {
     @DataBoundSetter
     public void setPattern(String pattern) {
         this.pattern = pattern;
+    }
+   
+    @DataBoundSetter
+    public void setBaselinePattern(String baselinePattern) {
+    	this.baselinePattern = baselinePattern;
     }
 
     @DataBoundSetter
@@ -49,6 +55,14 @@ public class CppcheckConfig implements Serializable {
 
     public String getPattern() {
         return pattern;
+    }
+    
+    public String getBaselinePattern() {
+    	return baselinePattern;
+    }
+    
+    public boolean isHasBaselinePattern() {
+    	return getBaselinePattern() != null;
     }
 
     @Deprecated

--- a/src/test/java/org/jenkinsci/plugins/cppcheck/CppcheckResultTest.java
+++ b/src/test/java/org/jenkinsci/plugins/cppcheck/CppcheckResultTest.java
@@ -1,0 +1,53 @@
+package org.jenkinsci.plugins.cppcheck;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import hudson.model.AbstractBuild;
+
+public class CppcheckResultTest {
+	
+	private AbstractBuild owner;
+	private CppcheckResult result1;
+	private CppcheckResult result2;
+
+	@Before
+	public void setUp() throws Exception {
+		owner = mock(AbstractBuild.class);
+		result1 = new CppcheckResult(new CppcheckStatistics(3, 3, 3, 3, 3, 3, 3, null), owner);
+		result2 = new CppcheckResult(new CppcheckStatistics(1, 1, 1, 1, 1, 1, 1, null), owner);
+	}
+
+	@Test
+	public void testCorrectNumberOfDiffsCalculatedWithoutBaseline() {
+		CppcheckStatistics diff1 = result1.getDiff();
+		
+		assertEquals(0, diff1.getNumberErrorSeverity());
+		assertEquals(0, diff1.getNumberWarningSeverity());
+		assertEquals(0, diff1.getNumberStyleSeverity());
+		assertEquals(0, diff1.getNumberPerformanceSeverity());
+		assertEquals(0, diff1.getNumberInformationSeverity());
+		assertEquals(0, diff1.getNumberNoCategorySeverity());
+		assertEquals(0, diff1.getNumberPortabilitySeverity());
+		assertEquals(0, diff1.getNumberTotal());
+	}
+	
+	@Test
+	public void testCorrectNumberOfDiffsCalculatedWithBaseline() {
+		result1.setBaselineResult(result2);
+		CppcheckStatistics diff1 = result1.getDiff();
+		
+		assertEquals(2, diff1.getNumberErrorSeverity());
+		assertEquals(2, diff1.getNumberWarningSeverity());
+		assertEquals(2, diff1.getNumberStyleSeverity());
+		assertEquals(2, diff1.getNumberPerformanceSeverity());
+		assertEquals(2, diff1.getNumberInformationSeverity());
+		assertEquals(2, diff1.getNumberNoCategorySeverity());
+		assertEquals(2, diff1.getNumberPortabilitySeverity());
+		assertEquals(14, diff1.getNumberTotal());
+	}
+
+}


### PR DESCRIPTION
Made it possible to specify which cppcheck result to compare against in diff / Delta parts. Uses a new parameter "baselinePattern", with the same semantics as the existing "pattern".

Also did some refactoring, as described in the ticket. 