### PR TITLE
[JENKINS-42613] Cppcheck publisher has no access to source files

### DIFF
--- a/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/CppcheckSource.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/CppcheckSource.java
@@ -92,7 +92,7 @@ public class CppcheckSource implements Serializable {
             if (tempFile.exists()) {
                 is = new FileInputStream(tempFile);
             } else {
-                throw new IOException("File doesn't exist: " + tempFile.getFileName());
+                throw new IOException("File doesn't exist: " + tempFile.getAbsoluteName());
             }
 
             splitSourceFile(highlightSource(is));

--- a/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/CppcheckSource.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/CppcheckSource.java
@@ -92,7 +92,7 @@ public class CppcheckSource implements Serializable {
             if (tempFile.exists()) {
                 is = new FileInputStream(tempFile);
             } else {
-                throw new IOException("File doesn't exist: " + tempFile.getAbsoluteName());
+                throw new IOException("File doesn't exist: " + tempFile.getAbsoluteFile());
             }
 
             splitSourceFile(highlightSource(is));

--- a/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/CppcheckSource.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/CppcheckSource.java
@@ -92,7 +92,7 @@ public class CppcheckSource implements Serializable {
             if (tempFile.exists()) {
                 is = new FileInputStream(tempFile);
             } else {
-                throw new IOException("File doesn't exist: " + file.getFileName());
+                throw new IOException("File doesn't exist: " + tempFile.getFileName());
             }
 
             splitSourceFile(highlightSource(is));

--- a/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/CppcheckSource.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/CppcheckSource.java
@@ -92,18 +92,7 @@ public class CppcheckSource implements Serializable {
             if (tempFile.exists()) {
                 is = new FileInputStream(tempFile);
             } else {
-                // Reading real workspace file is more incorrect than correct,
-                // but the code is left here for backward compatibility with
-                // plugin version 1.14 and less
-                if (cppcheckWorkspaceFile.getFileName() == null) {
-                    throw new IOException("The file doesn't exist.");
-                }
-
-                File file = new File(cppcheckWorkspaceFile.getFileName());
-                if (!file.exists()) {
-                    throw new IOException("Can't access the file: " + file.toURI());
-                }
-                is = new FileInputStream(file);
+                throw new IOException("File doesn't exist: " + file.getFileName());
             }
 
             splitSourceFile(highlightSource(is));

--- a/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/model/CppcheckWorkspaceFile.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cppcheck/model/CppcheckWorkspaceFile.java
@@ -105,7 +105,7 @@ public class CppcheckWorkspaceFile implements Serializable {
 
     public String getTempName(final Run<?, ?> owner) {
         if (fileName != null) {
-            return owner.getParent().getRootDir().getAbsolutePath() + "/"
+            return owner.getRootDir().getAbsolutePath() + "/"
                     + DIR_WORKSPACE_FILES + "/"
                     + Integer.toHexString(fileName.hashCode()) + ".tmp";
         }


### PR DESCRIPTION
When following a link to a source file from published results, the plugin throws an error e.g.:
```
Can't read file: Can't access the file: file:/home/tomcat/E:%5Cjenkins_new%5Cworkspace%5CSOME_JOB%5Ccomponent%5CPath%5CADSP2%5Csource.c

```
Part of the problem was that instead of reporting actual missing file, the plugin reports a different file which is used as a last-resort-backward-compatibility attempt. I have removed this legacy code to ensure that correct missing file is reported if it is actually missing:
```
Can't read file: File doesn't exist: /home/tomcat/.jenkins/jobs/SOME_JOB/workspace-files/3295432f.tmp
```
Now it's obvious that it fails because it looks for source code in the wrong place: under job's root instead of build's root.
This pull request addresses that by removing .getParent() before .getRootDir()

