### PR TITLE
[JENKINS-63808] cppcheck is not compatible with Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,12 +49,12 @@
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
         <jaxb.version>2.3.0</jaxb.version>
-        <jaxb2.maven.plugin.version>2.1</jaxb2.maven.plugin.version>
+        <jaxb2.maven.plugin.version>2.5.0</jaxb2.maven.plugin.version>
         <java2html.version>5.0</java2html.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.8.5</mockito.version>
         <dashboard.view.version>2.0</dashboard.view.version>
-	<jenkins.version>2.60.3</jenkins.version>
+	<jenkins.version>2.164</jenkins.version>
 	<java.level>8</java.level>
     </properties>
 

--- a/src/main/java/org/jenkinsci/plugins/cppcheck/parser/CppcheckParser.java
+++ b/src/main/java/org/jenkinsci/plugins/cppcheck/parser/CppcheckParser.java
@@ -7,6 +7,8 @@ import org.jenkinsci.plugins.cppcheck.model.Errors;
 import org.jenkinsci.plugins.cppcheck.model.Results;
 import org.jenkinsci.plugins.cppcheck.util.CppcheckLogger;
 
+import com.sun.xml.bind.v2.ContextFactory;
+
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
@@ -37,11 +39,12 @@ public class CppcheckParser implements Serializable {
         CppcheckReport report;
         AtomicReference<JAXBContext> jc = new AtomicReference<JAXBContext>();
         try {
-            jc.set(JAXBContext.newInstance(
+            jc.set(ContextFactory.createContext(new Class[] {
                     org.jenkinsci.plugins.cppcheck.model.Error.class,
                     org.jenkinsci.plugins.cppcheck.model.Errors.class,
                     org.jenkinsci.plugins.cppcheck.model.Cppcheck.class,
-                    org.jenkinsci.plugins.cppcheck.model.Results.class));
+			        org.jenkinsci.plugins.cppcheck.model.Results.class
+				}, null));
             Unmarshaller unmarshaller = jc.get().createUnmarshaller();
             org.jenkinsci.plugins.cppcheck.model.Results results = (org.jenkinsci.plugins.cppcheck.model.Results) unmarshaller.unmarshal(file);
             if (results.getCppcheck() == null) {
@@ -50,7 +53,10 @@ public class CppcheckParser implements Serializable {
             report = getReportVersion2(results);
         } catch (JAXBException jxe) {
             try {
-                jc.set(JAXBContext.newInstance(com.thalesgroup.jenkinsci.plugins.cppcheck.model.Error.class, com.thalesgroup.jenkinsci.plugins.cppcheck.model.Results.class));
+                jc.set(ContextFactory.createContext(new Class[] {
+					com.thalesgroup.jenkinsci.plugins.cppcheck.model.Error.class, 
+					com.thalesgroup.jenkinsci.plugins.cppcheck.model.Results.class
+				}, null));
                 Unmarshaller unmarshaller = jc.get().createUnmarshaller();
                 com.thalesgroup.jenkinsci.plugins.cppcheck.model.Results results = (com.thalesgroup.jenkinsci.plugins.cppcheck.model.Results) unmarshaller.unmarshal(file);
                 report = getReportVersion1(results);


### PR DESCRIPTION
I did the same changes as in the [performance-signature-dynatrace-plugin](https://issues.jenkins-ci.org/browse/JENKINS-55202?jql=project%20%3D%20JENKINS%20AND%20component%20%3D%20performance-signature-dynatrace-pluginl)

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
